### PR TITLE
XSS fix in comments

### DIFF
--- a/src/components/posts/singlePostComponent.vue
+++ b/src/components/posts/singlePostComponent.vue
@@ -35,7 +35,7 @@ export default defineComponent({
       return s.replace(
         /@\w+/g,
         "<span class='font-bold text-blue-200'>$&</span>"
-      );
+      ).replaceAll("<","&lt;");
     },
     submitComment() {
       this.submitCommentLoading = true;


### PR DESCRIPTION
There is not a good XSS filter in the comments section of BeReals. If someone embeds a payload in their comment, anyone seeing that comment on befake.fr will run the payload. Since all comments load with the posts, it automatically triggers once you enter the site.
Here is an example of a working payload:  `<img src=x onerror=alert(JSON.stringify(localStorage))>`.
It is trivial to steal the phone number and the authentication token of the user.

I do not understand Vue at all. I just noticed this vulnerability and I have applied the obvious fix. However, I am not sure if the way you are highlighting the tagged usernames is the best. I think that you should avoid using the v-html directive. 