### PR TITLE
sort countries by dial code

### DIFF
--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -1477,4 +1477,4 @@ const countries = [
   },
 ];
 
-export default countries;
+export default countries.sort((a, b) => parseInt(a.dialCode.substring(1)) - parseInt(b.dialCode.substring(1)));;


### PR DESCRIPTION
Before it was hard to find your dial code. Sorting them makes it way easier to find.