### PR TITLE
Login Overhaul

### DIFF
--- a/src/components/layout/Navbar.vue
+++ b/src/components/layout/Navbar.vue
@@ -10,7 +10,9 @@ export default {
         token: localStorage.getItem("token") ?? "",
         refreshToken: localStorage.getItem("refreshToken") ?? "",
         expiration: localStorage.getItem("expiration") ?? "",
-        phone: localStorage.getItem("phone") ?? "",
+        user_id: localStorage.getItem("user_id") ?? "",
+        fbrefreshtoken: localStorage.getItem("fbrefreshtoken") ?? "",
+        fbtoken: localStorage.getItem("fbtoken") ?? "",
       }),
       hideNavbar: true,
     };

--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -43,7 +43,7 @@
             <a href="https://www.github.com/rvaidun/">Github </a>
             <a href="https://www.instagram.com/rahulvaidun/">Instagram </a>
             <!-- email -->
-            <a href="mailto:rahul.vaidun@gmail.com">Email</a>
+            <a href="mailto:rahul@befake.fr">Email</a>
             <a href="https://ko-fi.com/rahulvaidun" class="font-bold"
               >Donation</a
             >

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -190,6 +190,13 @@ export default {
                 `${this.$store.state.proxyUrl}/https://auth.bereal.team/token?grant_type=firebase`,
                 {
                   method: "POST",
+                  headers: {
+                    accept: "application/json",
+                    "content-type": "application/json",
+                    "user-agent":
+                      "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
+                    "accept-language": "en-US,en;q=0.9",
+                  },
                   body: JSON.stringify({
                     grant_type: "firebase",
                     client_id: "android",

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -78,11 +78,20 @@ export default {
         console.log("phone number starts with {");
         try {
           const j = JSON.parse(this.phone);
-          if (j.phone && j.token && j.refreshToken && j.expiration) {
+          if (
+            j.token &&
+            j.refreshToken &&
+            j.expiration &&
+            j.user_id &&
+            j.fbrefreshtoken &&
+            j.fbtoken
+          ) {
             localStorage.setItem("token", j.token);
             localStorage.setItem("refreshToken", j.refreshToken);
             localStorage.setItem("expiration", j.expiration);
-            localStorage.setItem("phone", j.phone);
+            localStorage.setItem("user_id", j.user_id);
+            localStorage.setItem("fbrefreshtoken", j.fbrefreshtoken);
+            localStorage.setItem("fbtoken", j.fbtoken);
             await this.$store.dispatch("login");
           } else {
             throw "invalid json";
@@ -213,9 +222,9 @@ export default {
                 })
                 .then((data) => {
                   localStorage.setItem("token", data.access_token);
-                  localStorage.setItem("refresh_token", data.refresh_token);
+                  localStorage.setItem("refreshToken", data.refresh_token);
                   localStorage.expiration =
-                    Date.now() + parseInt(data.expiresIn) * 1000;
+                    Date.now() + parseInt(data.expires_in) * 1000;
                   this.loading = false;
                   this.$store.dispatch("login");
                 });

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -146,17 +146,73 @@ export default {
         }
       )
         .then((res) => res.json())
-        .then((data) => {
-          if (data.error) {
-            throw Error(data.error.message);
+        .then((idtokendata) => {
+          if (idtokendata.error) {
+            throw Error(idtokendata.error.message);
           }
-          localStorage.phone = this.phone;
-          localStorage.expiration =
-            Date.now() + parseInt(data.expiresIn) * 1000;
-          localStorage.refreshToken = data.refreshToken;
-          localStorage.token = data.idToken;
-          this.loading = false;
-          this.$store.dispatch("login");
+          fetch(
+            `${this.$store.state.proxyUrl}/https://securetoken.googleapis.com/v1/token?key=AIzaSyDwjfEeparokD7sXPVQli9NsTuhT6fJ6iA`,
+            {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                "x-firebase-client":
+                  "apple-platform/ios apple-sdk/19F64 appstore/true deploy/cocoapods device/iPhone13,2 fire-abt/8.15.0 fire-analytics/8.15.0 fire-auth/8.15.0 fire-db/8.15.0 fire-dl/8.15.0 fire-fcm/8.15.0 fire-fiam/8.15.0 fire-fst/8.15.0 fire-fun/8.15.0 fire-install/8.15.0 fire-ios/8.15.0 fire-perf/8.15.0 fire-rc/8.15.0 fire-str/8.15.0 firebase-crashlytics/8.15.0 os-version/15.5 xcode/13F100",
+                accept: "*/*",
+                "x-client-version": "iOS/FirebaseSDK/8.15.0/FirebaseCore-iOS",
+                "x-firebase-client-log-type": "0",
+                "x-ios-bundle-identifier": "AlexisBarreyat.BeReal",
+                "accept-language": "en",
+                "user-agent":
+                  "FirebaseAuth.iOS/8.15.0 AlexisBarreyat.BeReal/0.22.4 iPhone/15.5 hw/iPhone13_2",
+                "x-firebase-locale": "en",
+              },
+              body: JSON.stringify({
+                grant_type: "refresh_token",
+                refresh_token: idtokendata.refreshToken,
+              }),
+            }
+          )
+            .then((res) => {
+              if (!res.ok) {
+                throw Error(res.statusText);
+              }
+              return res.json();
+            })
+            .then((tokendata) => {
+              if (tokendata.error) {
+                throw Error(tokendata.error.message);
+              }
+              localStorage.setItem("fbrefreshtoken", tokendata.refresh_token);
+              localStorage.setItem("fbtoken", tokendata.id_token);
+              localStorage.setItem("user_id", tokendata.user_id);
+              fetch(
+                `${this.$store.state.proxyUrl}/https://auth.bereal.team/token?grant_type=firebase`,
+                {
+                  method: "POST",
+                  body: JSON.stringify({
+                    grant_type: "firebase",
+                    client_id: "android",
+                    client_secret: "F5A71DA-32C7-425C-A3E3-375B4DACA406",
+                    token: tokendata.id_token,
+                  }),
+                }
+              )
+                .then((res) => {
+                  if (!res.ok) {
+                    throw Error(res.statusText);
+                  }
+                  return res.json();
+                })
+                .then((data) => {
+                  localStorage.setItem("token", data.access_token);
+                  localStorage.setItem("refresh_token", data.refresh_token);
+                  localStorage.expiration =
+                    Date.now() + parseInt(data.expiresIn) * 1000;
+                  this.loading = false;
+                  this.$store.dispatch("login");
+                });
+            });
         })
         .catch((e) => {
           this.handleError(e);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -31,7 +31,9 @@ const store = createStore({
       localStorage.removeItem("token");
       localStorage.removeItem("expiration");
       localStorage.removeItem("refreshToken");
-      localStorage.removeItem("phone");
+      localStorage.removeItem("user_id");
+      localStorage.removeItem("fbrefreshtoken");
+      localStorage.removeItem("fbtoken");
       state.loggedIn = false;
     },
     login(state) {
@@ -97,76 +99,66 @@ const store = createStore({
       }
     },
     async getPosts({ commit, state, dispatch }) {
-      return new Promise((resolve, reject) => {
-        return dispatch("refresh")
-          .then((res) => {
-            Promise.all([
-              fetch(
-                `${state.proxyUrl}/https://mobile.bereal.com/api/feeds/friends`,
-                {
-                  method: "GET",
-                  headers: {
-                    accept: "application/json",
-                    "content-type": "application/json",
-                    "user-agent":
-                      "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
-                    "accept-language": "en-US,en;q=0.9",
-                    authorization: `Bearer ${localStorage.getItem("token")}` ?? "",
-                  },
-                }
-              )
-                .then((res) => {
-                  if (!res.ok) throw new Error("Error getting posts");
-                  return res.json();
-                })
-                .then((data) => {
-                  // move user to the top of the list
-                  for (let i = 0; i < data.length; i++) {
-                    if (data[i].ownerID === state.user.id) {
-                      // remove i and move to top
-                      let user = data.splice(i, 1);
-                      console.log(user);
-                      data.unshift(user[0]);
-                      data.posted = true;
-                      break;
-                    }
-                  }
-                  commit("posts", data);
-                }),
-              fetch(
-                `${state.proxyUrl}/https://mobile.bereal.com/api/person/me`,
-                {
-                  method: "GET",
-                  headers: {
-                    accept: "application/json",
-                    "content-type": "application/json",
-                    "user-agent":
-                      "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
-                    "accept-language": "en-US,en;q=0.9",
-                    authorization: `Bearer ${localStorage.getItem("token")}` ?? "",
-                  },
-                }
-              )
-                .then((res) => {
-                  if (!res.ok) throw new Error("Error getting user");
-                  return res.json();
-                })
-                .then((data) => {
-                  commit("user", data);
-                }),
-            ])
-              .then(() => {
-                console.log("resolving to true");
-                resolve(true);
+      return dispatch("refresh")
+        .then(() =>
+          Promise.all([
+            fetch(
+              `${state.proxyUrl}/https://mobile.bereal.com/api/feeds/friends`,
+              {
+                method: "GET",
+                headers: {
+                  accept: "application/json",
+                  "content-type": "application/json",
+                  "user-agent": "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
+                  "accept-language": "en-US,en;q=0.9",
+                  authorization:
+                    `Bearer ${localStorage.getItem("token")}` ?? "",
+                },
+              }
+            )
+              .then((res) => {
+                if (!res.ok) throw new Error("Error getting posts");
+                return res.json();
               })
-              .catch((err) => {
-                reject(err);
-              });
-          })
-          .catch((err) => {
-            reject(err);
-          });
-      });
+              .then((data) => {
+                // move user to the top of the list
+                for (let i = 0; i < data.length; i++) {
+                  if (data[i].ownerID === state.user.id) {
+                    // remove i and move to top
+                    let user = data.splice(i, 1);
+                    console.log(user);
+                    data.unshift(user[0]);
+                    data.posted = true;
+                    break;
+                  }
+                }
+                commit("posts", data);
+              }),
+            fetch(`${state.proxyUrl}/https://mobile.bereal.com/api/person/me`, {
+              method: "GET",
+              headers: {
+                accept: "application/json",
+                "content-type": "application/json",
+                "user-agent": "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
+                "accept-language": "en-US,en;q=0.9",
+                authorization: `Bearer ${localStorage.getItem("token")}` ?? "",
+              },
+            })
+              .then((res) => {
+                if (!res.ok) throw new Error("Error getting user");
+                return res.json();
+              })
+              .then((data) => {
+                commit("user", data);
+              }),
+          ])
+        )
+        .then(() => {
+          return true;
+        })
+        .catch((err) => {
+          reject(err);
+        });
     },
     async getUser({ commit, state, dispatch }) {
       // const x = await dispatch("refresh");

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -111,7 +111,7 @@ const store = createStore({
                     "user-agent":
                       "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
                     "accept-language": "en-US,en;q=0.9",
-                    authorization: localStorage.getItem("token") ?? "",
+                    authorization: `Bearer ${localStorage.getItem("token")}` ?? "",
                   },
                 }
               )
@@ -143,7 +143,7 @@ const store = createStore({
                     "user-agent":
                       "BeReal/7242 CFNetwork/1333.0.4 Darwin/21.5.0",
                     "accept-language": "en-US,en;q=0.9",
-                    authorization: localStorage.getItem("token") ?? "",
+                    authorization: `Bearer ${localStorage.getItem("token")}` ?? "",
                   },
                 }
               )


### PR DESCRIPTION
Unfortunately BeReal has completely overhauled the login workflow breaking befake.fr.
I copied over the fixes made in the pull request at https://github.com/notmarek/BeFake/pull/80

The fetch on line 189 does not work. Chrome network tools shows a 400 bad request response 
<img width="672" alt="image" src="https://user-images.githubusercontent.com/19789246/234515023-190feff5-7bd9-4048-9af5-dccadcd0659f.png">

Running the following python code successfully returns an access token
```py
import requests

res = requests.post('https://warm-scrubland-06418.herokuapp.com/https://auth.bereal.team/token?grant_type=firebase',data={
            "grant_type": "firebase",
             "client_id": "android",
             "client_secret": "F5A71DA-32C7-425C-A3E3-375B4DACA406",
             "token": "{{YOUR ID TOKEN HERE}}",
},
             headers={
                "origin": "https://warm-scrubland-06418.herokuapp.com"
             }
)
print(res.text)
```

TLDR: Bug for fetch on line 189

