### PR TITLE
Fix Github PR Action

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,7 +2,7 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+'on': pull_request_target
 jobs:
   build_and_preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hey 👋

My two last PRs failed during the Github Action. 
This PR could be a fix, but see article below:

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/