### PR TITLE
Fix images ratio being displayed in landscape in BeReal. memories

### DIFF
--- a/src/components/posts/uploadPost.vue
+++ b/src/components/posts/uploadPost.vue
@@ -88,14 +88,14 @@ export default {
           takenAt: taken_at,
           backCamera: {
             bucket: uploadUrlData.data[0].bucket,
-            height: 1500,
-            width: 2000,
+            height: 2000,
+            width: 1500,
             path: uploadUrlData.data[0].path,
           },
           frontCamera: {
             bucket: uploadUrlData.data[1].bucket,
-            height: 1500,
-            width: 2000,
+            height: 2000,
+            width: 1500,
             path: uploadUrlData.data[1].path,
           },
         };


### PR DESCRIPTION
When accessing BeReal. memories via the mobile app, the images are getting displayed in a wrong ratio (4:3 -> landscape), because of the image's width and height getting defined as 4:3 in the API request on upload.
Exchanging the width and the height's size should fix the issue.